### PR TITLE
25 open listen socket connection socket with config information

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,7 +40,9 @@ cmake_install.cmake
 compile_commands.json
 
 # Visual Studio Code C++ extension
+.vscode/
 .vscode/c_cpp_properties.json
 .vscode/tasks.json
 .vscode/launch.json
+.vscode/settings.json
 .vscode/extensions.json

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -176,34 +176,34 @@ void Config::parseMimeFile(const char *file_path) {
   }
 }
 
-std::string Config::getServerProgramName() const {
+const std::string &Config::getServerProgramName() const {
   return server_program_name_;
 }
 
-std::string Config::getHttpVersion() const {
+const std::string &Config::getHttpVersion() const {
   return http_version_;
 }
 
-std::string Config::getCgiVersion() const {
+const std::string &Config::getCgiVersion() const {
   return cgi_version_;
 }
 
-std::vector<ServerBlock> Config::getServerBlocks() const {
+const std::vector<ServerBlock> &Config::getServerBlocks() const {
   return server_blocks_;
 }
 
-int Config::getTimeout() const {
+const int &Config::getTimeout() const {
   return timeout_;
 }
 
-std::string Config::getCgiPath() const {
+const std::string &Config::getCgiPath() const {
   return cgi_path_;
 }
 
-std::map<std::string, std::string> Config::getStausMessages() const {
+const std::map<std::string, std::string> &Config::getStausMessages() const {
   return status_messages_;
 }
 
-std::map<std::string, std::string> Config::getMimeTypes() const {
+const std::map<std::string, std::string> &Config::getMimeTypes() const {
   return mime_types_;
 }

--- a/src/Config.hpp
+++ b/src/Config.hpp
@@ -18,14 +18,14 @@
 class Config {
  public:
   explicit Config(const char *file_path);
-  std::string getServerProgramName() const;
-  std::string getHttpVersion() const;
-  std::string getCgiVersion() const;
-  std::string getCgiPath() const;
-  int getTimeout() const;
-  std::map<std::string, std::string> getStausMessages() const;
-  std::map<std::string, std::string> getMimeTypes() const;
-  std::vector<ServerBlock> getServerBlocks() const;
+  const std::string &getServerProgramName() const;
+  const std::string &getHttpVersion() const;
+  const std::string &getCgiVersion() const;
+  const std::string &getCgiPath() const;
+  const int &getTimeout() const;
+  const std::map<std::string, std::string> &getStausMessages() const;
+  const std::map<std::string, std::string> &getMimeTypes() const;
+  const std::vector<ServerBlock> &getServerBlocks() const;
 
  private:
   void parseConfigFile(const char *file_path);

--- a/src/Connection.cpp
+++ b/src/Connection.cpp
@@ -10,9 +10,9 @@
 #include "src/Server.hpp"
 #include "src/utils.hpp"
 
-Connection::Connection(int connection_socket, const Kqueue& kqueue)
+Connection::Connection(int connection_socket, const Kqueue& kqueue, const Config& config)
     : connection_socket_(connection_socket), request_message_(response_status_code_), response_message_(response_status_code_), kqueue_(kqueue),
-      response_status_code_(200) {}
+      config_(config), response_status_code_(200) {}
 
 int Connection::getConnectionSocket() const {
   return connection_socket_;

--- a/src/Connection.hpp
+++ b/src/Connection.hpp
@@ -3,22 +3,27 @@
 #ifndef SRC_CONNECTION_HPP_
 #define SRC_CONNECTION_HPP_
 
+#include <netinet/in.h>
 #include <queue>
 #include <string>
 
+#include "src/Config.hpp"
+#include "src/ServerBlock.hpp"
+#include "src/LocationBlock.hpp"
 #include "src/Kqueue.hpp"
 #include "src/RequestMessage.hpp"
 #include "src/ResponseMessage.hpp"
-#include "src/ReturnState.hpp"
+#include "src/utils.hpp"
 
 class Connection {
  public:
-  Connection(int connection_socket, const Kqueue& kqueue);
+  Connection(int connection_socket, const Kqueue& kqueue, const Config& config);
   int getConnectionSocket() const;
   char *getReadBuffer();
   ReturnState work();
   bool checkReadSuccess();
   bool checkTimeOut();
+  void setConfigInfo();
   void parsingRequestMessage();
   void executeCGIProcess();
   void openStaticPage();
@@ -42,7 +47,11 @@ class Connection {
   RequestMessage request_message_;
   ResponseMessage response_message_;
   State state_;
-  Kqueue kqueue_;
+  const Kqueue &kqueue_;
+  const Config &config_;
+  ServerBlock *cur_server_;
+  LocationBlock *cur_location_;
+  struct sockaddr_in client_addr_;
   int response_status_code_;
 };
 

--- a/src/LocationBlock.cpp
+++ b/src/LocationBlock.cpp
@@ -110,30 +110,30 @@ void LocationBlock::parseLocationBlock(std::fstream &file) {
   }
 }
 
-std::string LocationBlock::getUrl() const {
+const std::string &LocationBlock::getUrl() const {
   return url_;
 }
 
-std::string LocationBlock::getRootDir() const {
+const std::string &LocationBlock::getRootDir() const {
   return root_dir_;
 }
 
-std::set<std::string> LocationBlock::getAllowedMethod() const {
+const std::set<std::string> &LocationBlock::getAllowedMethod() const {
   return allowed_method_;
 }
 
-std::string LocationBlock::getDirectoryListing() const {
+const std::string &LocationBlock::getDirectoryListing() const {
   return directory_listing_;
 }
 
-std::string LocationBlock::getIndex() const {
+const std::string &LocationBlock::getIndex() const {
   return index_;
 }
 
-std::string LocationBlock::getCgiExention() const {
+const std::string &LocationBlock::getCgiExention() const {
   return cgi_extension_;
 }
 
-std::string LocationBlock::getRedirection() const {
+const std::string &LocationBlock::getRedirection() const {
   return redirection_;
 }

--- a/src/LocationBlock.hpp
+++ b/src/LocationBlock.hpp
@@ -15,13 +15,13 @@
 class LocationBlock {
  public:
   explicit LocationBlock(std::fstream &file, std::string url);
-  std::string getUrl() const;
-  std::string getRootDir() const;
-  std::set<std::string> getAllowedMethod() const;
-  std::string getDirectoryListing() const;
-  std::string getIndex() const;
-  std::string getCgiExention() const;
-  std::string getRedirection() const;
+  const std::string &getUrl() const;
+  const std::string &getRootDir() const;
+  const std::set<std::string> &getAllowedMethod() const;
+  const std::string &getDirectoryListing() const;
+  const std::string &getIndex() const;
+  const std::string &getCgiExention() const;
+  const std::string &getRedirection() const;
 
  private: 
   void parseLocationBlock(std::fstream &file);

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -16,7 +16,7 @@
 #include "src/utils.hpp"
 
 Server::Server(const Config &config, const std::vector<int> &listen_sockets)
-    : config_(config), listen_sockets_(listen_sockets) {
+    : config_(config), listen_sockets_(listen_sockets), kqueue_() {
   for (size_t i = 0; i < listen_sockets.size(); ++i) {
     kqueue_.setEvent(listen_sockets[i], EVFILT_READ, EV_ADD, 0, 0, NULL);
   }
@@ -28,7 +28,7 @@ Connection *Server::acceptClient(int listen_socket) {
     throw 1;
   }
   fcntl(connection_socket, F_SETFL, O_NONBLOCK);
-  Connection *p = new Connection(connection_socket, kqueue_);
+  Connection *p = new Connection(connection_socket, kqueue_, config_);
   kqueue_.setEvent(connection_socket, EVFILT_READ, EV_ADD, 0, 0, p);
   kqueue_.setEvent(connection_socket, EVFILT_WRITE, EV_ADD | EV_DISABLE, 0, 0, p);
   return p;
@@ -87,4 +87,12 @@ void Server::run() {
       }
     }
   }
+}
+
+const Config &Server::getConfig() const {
+  return config_;
+}
+
+const Kqueue &Server::getKqueue() const {
+  return kqueue_;
 }

--- a/src/Server.hpp
+++ b/src/Server.hpp
@@ -12,14 +12,16 @@
 class Server {
  public:
   Server(const Config &config, const std::vector<int> &listen_sockets);
+  const Config &getConfig() const;
+  const Kqueue &getKqueue() const;
   void run();
 
  private:
   Connection *acceptClient(int listen_socket);
   bool isListenSocketEvent(int catch_fd);
 
-  Config config_;
-  std::vector<int> listen_sockets_;
+  const Config &config_;
+  const std::vector<int> &listen_sockets_;
   Kqueue kqueue_;
 };
 

--- a/src/ServerBlock.cpp
+++ b/src/ServerBlock.cpp
@@ -130,26 +130,26 @@ void ServerBlock::parseServerBlock(std::fstream &file) {
   }
 }
 
-std::map<std::string, std::string> ServerBlock::getDefaultErrorPages(void) const {
+const std::map<std::string, std::string> &ServerBlock::getDefaultErrorPages(void) const {
   return default_error_pages_;
 }
 
-int ServerBlock::getClientBodySize() const {
+const int &ServerBlock::getClientBodySize() const {
   return client_body_size_;
 }
 
-std::string ServerBlock::getServerIP() const {
+const std::string &ServerBlock::getServerIP() const {
   return server_ip_;
 }
 
-int ServerBlock::getServerPort() const {
+const int &ServerBlock::getServerPort() const {
   return server_port_;
 }
 
-std::string ServerBlock::getServerName() const {
+const std::string &ServerBlock::getServerName() const {
   return server_name_;
 }
 
-std::vector<LocationBlock> ServerBlock::getLocationBlocks() const {
+const std::vector<LocationBlock> &ServerBlock::getLocationBlocks() const {
   return location_blocks_;
 }

--- a/src/ServerBlock.hpp
+++ b/src/ServerBlock.hpp
@@ -18,12 +18,12 @@
 class ServerBlock {
  public:
   explicit ServerBlock(std::fstream &file);
-  std::map<std::string, std::string> getDefaultErrorPages(void) const;
-  int getClientBodySize() const;
-  std::string getServerIP() const;
-  int getServerPort() const;
-  std::string getServerName() const;
-  std::vector<LocationBlock> getLocationBlocks() const;
+  const std::map<std::string, std::string> &getDefaultErrorPages(void) const;
+  const int &getClientBodySize() const;
+  const std::string &getServerIP() const;
+  const int &getServerPort() const;
+  const std::string &getServerName() const;
+  const std::vector<LocationBlock> &getLocationBlocks() const;
 
  private:
   void parseServerBlock(std::fstream &file);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,6 +3,7 @@
 #include <arpa/inet.h>
 #include <netinet/in.h>
 #include <fcntl.h>
+#include <errno.h>
 
 #include <cstdio>
 #include <cstdlib>
@@ -10,15 +11,27 @@
 
 #include "src/Config.hpp"
 #include "src/Server.hpp"
+#include "src/utils.hpp"
 
-void setupListenSocket(Config &config, std::vector<int> &listen_sockets) {
-  struct sockaddr_in listen_addr;
-  int listen_socket;
+static in_addr changeIpToBinary(std::string ip) {
+  struct in_addr ret;
 
-  for (int i = 0; i < config.ports_.size(); ++i) {
+  std::vector<std::string> ip_token = split(ip, ".");
+  ret.s_addr = ((atoi(ip_token[0].c_str()) << 24) | (atoi(ip_token[1].c_str()) << 16)
+                | (atoi(ip_token[2].c_str()) << 8) | atoi(ip_token[3].c_str()));
+  return ret;
+}
+
+static void setupListenSocket(Config &config, std::vector<int> &listen_sockets) {
+  const std::vector<ServerBlock> &server_blocks = config.getServerBlocks();
+
+  for (int i = 0; i < server_blocks.size(); ++i) {
+    struct sockaddr_in listen_addr;
+    memset(&listen_addr, 0, sizeof(listen_addr));
+    int listen_socket;
     listen_addr.sin_family = AF_INET;
-    listen_addr.sin_port = htons(config.ports_[i]);
-    // socklen_t server_addr_len;
+    listen_addr.sin_port = htons(server_blocks[i].getServerPort());
+    listen_addr.sin_addr = changeIpToBinary(server_blocks[i].getServerIP());
 
     listen_socket = socket(PF_INET, SOCK_STREAM, 0);
     if (fcntl(listen_socket, F_SETFL, O_NONBLOCK) == -1) {
@@ -32,8 +45,13 @@ void setupListenSocket(Config &config, std::vector<int> &listen_sockets) {
     if (bind(listen_socket,
              reinterpret_cast<const struct sockaddr *>(&listen_addr),
              sizeof(listen_addr)) == -1) {
-      std::perror("bind() error");
-      exit(1);
+      if (errno == EADDRINUSE) {
+        continue;
+      }
+      else {
+        std::perror("bind() error");
+        exit(1);
+      }
     }
     if (listen(listen_socket, 5) == -1) {
       std::perror("listen() error");

--- a/test/listen_test.cpp
+++ b/test/listen_test.cpp
@@ -1,0 +1,78 @@
+// Copyright 2023 ean, hanbkim, jiyunpar
+
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <fcntl.h>
+#include <errno.h>
+
+#include <cstdio>
+#include <iostream>
+#include <cstdlib>
+#include <vector>
+
+#include "../src/Config.hpp" 
+#include "src/Server.hpp"
+#include "src/utils.hpp"
+
+static in_addr changeIpToBinary(std::string ip) {
+  struct in_addr ret;
+
+  std::vector<std::string> ip_token = split(ip, ".");
+  ret.s_addr = ((atoi(ip_token[0].c_str()) << 24) | (atoi(ip_token[1].c_str()) << 16)
+                | (atoi(ip_token[2].c_str()) << 8) | atoi(ip_token[3].c_str()));
+  return ret;
+}
+
+static void setupListenSocket(Config &config, std::vector<int> &listen_sockets) {
+  const std::vector<ServerBlock> &server_blocks = config.getServerBlocks();
+
+  for (int i = 0; i < server_blocks.size(); ++i) {
+    struct sockaddr_in listen_addr;
+    memset(&listen_addr, 0, sizeof(listen_addr));
+    int listen_socket;
+    listen_addr.sin_family = AF_INET;
+    listen_addr.sin_port = htons(server_blocks[i].getServerPort());
+    listen_addr.sin_addr = changeIpToBinary(server_blocks[i].getServerIP());
+
+    listen_socket = socket(PF_INET, SOCK_STREAM, 0);
+    if (fcntl(listen_socket, F_SETFL, O_NONBLOCK) == -1) {
+      std::perror("fcntl() error");
+      exit(1);
+    }
+    if (listen_socket == -1) {
+      std::perror("socket() error");
+      exit(1);
+    }
+    if (bind(listen_socket,
+             reinterpret_cast<const struct sockaddr *>(&listen_addr),
+             sizeof(listen_addr)) == -1) {
+      if (errno == EADDRINUSE) {
+        continue;
+      }
+      else {
+        std::perror("bind() error");
+        exit(1);
+      }
+    }
+    if (listen(listen_socket, 5) == -1) {
+      std::perror("listen() error");
+      exit(1);
+    }
+    listen_sockets.push_back(listen_socket);
+  }
+}
+int main(int argc, char **argv) {
+  if (argc != 2) {
+    std::cout << "Usage : ./conf_test [file]\n";
+    return 1;
+  }
+  try {
+    Config test(argv[1]);
+    std::vector<int> listen_soket;
+    setupListenSocket(test, listen_soket);
+    std::cout << "done" << std::endl;
+  } catch (int) {
+    std::cout << "fail to construct class" << '\n';
+  } 
+  return 0;
+}


### PR DESCRIPTION
listen socket open logic 구현
- config 파일의 여러 서버 블록 정보를 참조하여 서버 ip, port에 맞는 listen socket을 open, bind, listen 하는 함수를 구현하였습니다.
- '.'으로 구분된 ip 주소를 이진수로 변환하는 함수를 만들었습니다.

이외 다른 변경점들은 관련 이슈에 변경 목록 적어 두었으니 참고 바랍니다.