### PR TITLE
43 implement chunked body message and detailed exception handling

### DIFF
--- a/src/RequestMessage.cpp
+++ b/src/RequestMessage.cpp
@@ -6,7 +6,7 @@
 
 #include "src/utils.hpp"
 
-typedef std::vector<char>::iterator vector_iterator;
+typedef std::deque<char>::iterator deque_iterator;
 typedef std::map<std::string, std::string>::iterator map_iterator;
 static const char kCrlf[] = {'\r', '\n'};
 static const size_t kCrlfLength = 2;
@@ -75,7 +75,7 @@ void RequestMessage::parseStartLine() {
 }
 
 void RequestMessage::parseMethod() {
-  vector_iterator space_pos = std::find(leftover_.begin(), leftover_.end(), ' ');
+  deque_iterator space_pos = std::find(leftover_.begin(), leftover_.end(), ' ');
   if (space_pos == leftover_.end()) {
     return;
   }
@@ -86,7 +86,7 @@ void RequestMessage::parseMethod() {
 }
 
 void RequestMessage::parseUri() {
-  vector_iterator space_pos = std::find(leftover_.begin(), leftover_.end(), ' ');
+  deque_iterator space_pos = std::find(leftover_.begin(), leftover_.end(), ' ');
   if (space_pos == leftover_.end()) {
     return;
   }
@@ -98,7 +98,7 @@ void RequestMessage::parseUri() {
 }
 
 void RequestMessage::parseProtocol() {
-  vector_iterator crlf_pos = std::search(leftover_.begin(), leftover_.end(), kCrlf, kCrlf + kCrlfLength);
+  deque_iterator crlf_pos = std::search(leftover_.begin(), leftover_.end(), kCrlf, kCrlf + kCrlfLength);
   if (crlf_pos == leftover_.end()) {
     return;
   }
@@ -114,7 +114,7 @@ void RequestMessage::parseProtocol() {
 }
 
 void RequestMessage::skipCrlf() {
-  vector_iterator line_pos;
+  deque_iterator line_pos;
   while (true) {
     line_pos = std::search(leftover_.begin(), leftover_.end(), kCrlf, kCrlf + kCrlfLength);
     if (line_pos == leftover_.end()) {
@@ -136,7 +136,7 @@ void RequestMessage::skipCrlf() {
 }
 
 void RequestMessage::parseHeaderLine() {
-  vector_iterator line_pos;
+  deque_iterator line_pos;
   while (true) {
     line_pos = std::search(leftover_.begin(), leftover_.end(), kCrlf, kCrlf + kCrlfLength);
     if (line_pos == leftover_.end()) {
@@ -216,7 +216,7 @@ void RequestMessage::parseChunkBody() {
 }
 
 void RequestMessage::parseChunkSize() {
-  vector_iterator crlf_pos = std::search(leftover_.begin(), leftover_.end(), kCrlf, kCrlf + kCrlfLength);
+  deque_iterator crlf_pos = std::search(leftover_.begin(), leftover_.end(), kCrlf, kCrlf + kCrlfLength);
   if (crlf_pos == leftover_.end()) {
     return;
   }
@@ -242,7 +242,7 @@ void RequestMessage::parseChunkSize() {
 }
 
 void RequestMessage::parseChunkData() {
-  vector_iterator crlf_pos = std::search(leftover_.begin(), leftover_.end(), kCrlf, kCrlf + kCrlfLength);
+  deque_iterator crlf_pos = std::search(leftover_.begin(), leftover_.end(), kCrlf, kCrlf + kCrlfLength);
   if (crlf_pos == leftover_.end()) {
     return;
   }
@@ -259,7 +259,7 @@ void RequestMessage::parseChunkData() {
 }
 
 void RequestMessage::parseTrailerField() {
-  vector_iterator line_pos;
+  deque_iterator line_pos;
   while (true) {
     line_pos = std::search(leftover_.begin(), leftover_.end(), kCrlf, kCrlf + kCrlfLength);
     if (line_pos == leftover_.end()) {

--- a/src/RequestMessage.cpp
+++ b/src/RequestMessage.cpp
@@ -38,7 +38,7 @@ void RequestMessage::parseComplete(int response_status_code) {
 }
 
 ReturnState RequestMessage::parse(const char *buffer, size_t read) {
-  if (read <= 0 && leftover_.empty()) {
+  if (read == 0 && leftover_.empty()) {
     return AGAIN;
   }
 

--- a/src/RequestMessage.cpp
+++ b/src/RequestMessage.cpp
@@ -32,169 +32,158 @@ bool RequestMessage::writeDone() {
   return false;
 }
 
+void RequestMessage::parseComplete(int response_status_code) {
+  state_ = kParseComplete;
+  response_status_code_ = response_status_code;
+}
+
 ReturnState RequestMessage::parse(const char *buffer, size_t read) {
-  if (read <= 0 && leftover_.empty())
+  if (read <= 0 && leftover_.empty()) {
     return AGAIN;
+  }
 
   appendLeftover(buffer, read);
 
-  if (parseStartLine() == SUCCESS) {
-    return SUCCESS;
+  parseStartLine();
+  if (state_ == kSkipCrlf) {
+    skipCrlf();
   }
-  if (skipCrlf() == SUCCESS) {
-    return SUCCESS;
+  if (state_ == kHeaderLine) {
+    parseHeaderLine();
   }
-  if (parseHeaderLine() == SUCCESS) {
-    return SUCCESS;
+  if (state_ == kContentLength) {
+    parseContentLengthBody();
   }
-  if (parseContentLengthBody() == SUCCESS) {
-    return SUCCESS;
-  }
-  if (parseChunkBody() == SUCCESS) {
+  parseChunkBody();
+
+  if (state_ == kParseComplete) {
     return SUCCESS;
   }
   return AGAIN;
 }
 
-ReturnState RequestMessage::parseStartLine() {
-  if (parseMethod() == SUCCESS) {
-    return SUCCESS;
+void RequestMessage::parseStartLine() {
+  if (state_ == kMethod) {
+    parseMethod();
   }
-  if (parseUri() == SUCCESS) {
-    return SUCCESS;
+  if (state_ == kUri) {
+    parseUri();
   }
-  if (parseProtocol() == SUCCESS) {
-    return SUCCESS;
+  if (state_ == kProtocol) {
+    parseProtocol();
   }
-  return AGAIN;
 }
 
-ReturnState RequestMessage::parseMethod() {
-  if (state_ != kMethod) {
-    return AGAIN;
-  }
+void RequestMessage::parseMethod() {
   vector_iterator space_pos = std::find(leftover_.begin(), leftover_.end(), ' ');
-  if (space_pos == leftover_.end())
-    return AGAIN;
+  if (space_pos == leftover_.end()) {
+    return;
+  }
 
   method_.insert(method_.begin(), leftover_.begin(), space_pos);
   leftover_.erase(leftover_.begin(), space_pos + 1);
   state_ = kUri;
-  return AGAIN;
 }
 
-ReturnState RequestMessage::parseUri() {
-  if (state_ != kUri) {
-    return AGAIN;
-  }
-
+void RequestMessage::parseUri() {
   vector_iterator space_pos = std::find(leftover_.begin(), leftover_.end(), ' ');
-  if (space_pos == leftover_.end())
-    return AGAIN;
+  if (space_pos == leftover_.end()) {
+    return;
+  }
 
   uri_.insert(uri_.begin(), leftover_.begin(), space_pos);
   leftover_.erase(leftover_.begin(), space_pos + 1);
   // Todo: uri 분석
   state_ = kProtocol;
-  return AGAIN;
 }
 
-ReturnState RequestMessage::parseProtocol() {
-  if (state_ != kProtocol) {
-    return AGAIN;
-  }
-
+void RequestMessage::parseProtocol() {
   vector_iterator crlf_pos = std::search(leftover_.begin(), leftover_.end(), kCrlf, kCrlf + kCrlfLength);
-  if (crlf_pos == leftover_.end())
-    return AGAIN;
+  if (crlf_pos == leftover_.end()) {
+    return;
+  }
 
   protocol_.insert(protocol_.begin(), leftover_.begin(), crlf_pos);
+  leftover_.erase(leftover_.begin(), crlf_pos + kCrlfLength);
   std::for_each(protocol_.begin(), protocol_.end(), toLower);
+
   if (protocol_ != "http/1.1") {
-    state_ = kParseDone;
-    response_status_code_ = 400;
-    return SUCCESS;
+    parseComplete(400);
+    return;
   }
   state_ = kSkipCrlf;
-  leftover_.erase(leftover_.begin(), crlf_pos + 2);
-  return AGAIN;
 }
 
-ReturnState RequestMessage::skipCrlf() {
-  if (state_ != kSkipCrlf)
-    return AGAIN;
-  /*
-   * skipCrlf() startline이 들어오고 header가 들어오기 전 공백이 들어오면 400 에러를 뱉어야함. 그리고 crlf만 들어온 문자 스킵할 수 있어야 함.
-   */
+void RequestMessage::skipCrlf() {
   vector_iterator line_pos;
-
   while (true) {
     line_pos = std::search(leftover_.begin(), leftover_.end(), kCrlf, kCrlf + kCrlfLength);
-    if (line_pos == leftover_.end())
-      return AGAIN;
+    if (line_pos == leftover_.end()) {
+      return;
+    }
 
     std::string field_line(leftover_.begin(), line_pos);
     if (field_line.empty()) {
       leftover_.erase(leftover_.begin(), line_pos + kCrlfLength);
       continue;
     }
-
     if (!isblank(field_line.front())) {
       state_ = kHeaderLine;
-      return AGAIN;
+      return;
     }
-
-    response_status_code_ = 400;
-    return SUCCESS;
+    parseComplete(400);
+    return;
   }
 }
 
-ReturnState RequestMessage::parseHeaderLine() {
-  if (state_ != kHeaderLine)
-    return AGAIN;
-
+void RequestMessage::parseHeaderLine() {
   vector_iterator line_pos;
   while (true) {
     line_pos = std::search(leftover_.begin(), leftover_.end(), kCrlf, kCrlf + kCrlfLength);
     if (line_pos == leftover_.end()) {
-      return AGAIN;
+      return;
     }
 
     std::string field_line(leftover_.begin(), line_pos);
     leftover_.erase(leftover_.begin(), line_pos + kCrlfLength);
-
     if (field_line.empty()) {
-      return checkBodyType();
+      checkBodyType();
+      return;
     }
-
-    size_t colon_pos = field_line.find(':');
-    if (colon_pos != std::string::npos) {
-      std::string field_name(field_line.substr(0, colon_pos));
-      if (field_name.find(' ') != std::string::npos) {
-        response_status_code_ = 400;
-        return SUCCESS;
-      }
-      std::for_each(field_name.begin(), field_name.end(), toLower);
-
-      std::string field_value(field_line.begin() + colon_pos + 1, field_line.end());
-      if (field_value.find('\0') != std::string::npos) {
-        state_ = kParseDone;
-        response_status_code_ = 400;
-        return SUCCESS;
-      }
-      trim(field_value);
-      headers_[field_name] = field_value;
-    }
+    parseField(field_line);
   }
 }
 
-ReturnState RequestMessage::checkBodyType() {
+void RequestMessage::parseField(std::string &field) {
+  size_t colon_pos = field.find(':');
+  if (colon_pos == std::string::npos) {
+    return;
+  }
+
+  std::string field_name(field.begin(), field.begin() + colon_pos);
+  if (field_name.find(' ') != std::string::npos) {
+    parseComplete(400);
+    return;
+  }
+
+  std::string field_value(field.begin() + colon_pos + 1, field.end());
+  if (field_value.find('\0') != std::string::npos) {
+    parseComplete(400);
+    return;
+  }
+
+  std::for_each(field_name.begin(), field_name.end(), toLower);
+  trim(field_value);
+  headers_[field_name] = field_value;
+}
+
+void RequestMessage::checkBodyType() {
   map_iterator content_length = headers_.find("content-length");
   map_iterator chunked = headers_.find("transfer-encoding");
 
   if (content_length != headers_.end() && chunked != headers_.end()) {
-    response_status_code_ = 400;
-    return SUCCESS;
+    parseComplete(400);
+    return;
   }
   if (content_length != headers_.end()) {
     content_length_ = std::strtol(content_length->second.c_str(), NULL, 10);
@@ -204,120 +193,89 @@ ReturnState RequestMessage::checkBodyType() {
     content_length_ = 0;
     state_ = kChunkSize;
   }
-  return AGAIN;
 }
 
-ReturnState RequestMessage::parseContentLengthBody() {
-  if (state_ != kContentLength) {
-    return AGAIN;
-  }
+void RequestMessage::parseContentLengthBody() {
   if (leftover_.size() < content_length_) {
-    return AGAIN;
+    return;
   }
+
   body_.insert(body_.end(), leftover_.begin(), leftover_.begin() + content_length_);
   leftover_.erase(leftover_.begin(), leftover_.begin() + content_length_);
-  state_ = kParseDone;
-  return SUCCESS;
+  parseComplete(200);
 }
 
-ReturnState RequestMessage::parseChunkBody() {
-  if (parseChunkSize() == SUCCESS) {
-    return SUCCESS;
+void RequestMessage::parseChunkBody() {
+  if (state_ == kChunkSize) {
+    parseChunkSize();
   }
-  if (parseChunkData() == SUCCESS) {
-    return SUCCESS;
+  if (state_ == kChunkData) {
+    parseChunkData();
   }
-  if (parseTrailerField() == SUCCESS) {
-    return SUCCESS;
+  if (state_ == kTrailerField) {
+    parseTrailerField();
   }
-  return AGAIN;
 }
 
-ReturnState RequestMessage::parseChunkSize() {
-  if (state_ != kChunkSize) {
-    return AGAIN;
+void RequestMessage::parseChunkSize() {
+  vector_iterator crlf_pos = std::search(leftover_.begin(), leftover_.end(), kCrlf, kCrlf + kCrlfLength);
+  if (crlf_pos == leftover_.end()) {
+    return;
   }
-  vector_iterator crlf_pos;
-
-  crlf_pos = std::search(leftover_.begin(), leftover_.end(), kCrlf, kCrlf + kCrlfLength);
-  if (crlf_pos == leftover_.end())
-    return AGAIN;
 
   std::string chunk_size(leftover_.begin(), crlf_pos);
   leftover_.erase(leftover_.begin(), crlf_pos + kCrlfLength);
   if (chunk_size.empty()) {
-    state_ = kParseDone;
-    return SUCCESS;
+    parseComplete(400);
+    return;
   }
-
   char *end;
   chunk_size_ = strtol(chunk_size.c_str(), &end, 16);
   if (*end != '\0') {
-    response_status_code_ = 400;
-    state_ = kParseDone;
-    return SUCCESS;
+    parseComplete(400);
+    return;
   }
   if (chunk_size_ == 0) {
     state_ = kTrailerField;
-    return AGAIN;
+    return;
   }
   state_ = kChunkData;
-  return AGAIN;
 }
 
-ReturnState RequestMessage::parseChunkData() {
-  if (state_ != kChunkData) {
-    return AGAIN;
-  }
+void RequestMessage::parseChunkData() {
   vector_iterator crlf_pos = std::search(leftover_.begin(), leftover_.end(), kCrlf, kCrlf + kCrlfLength);
-  if (crlf_pos == leftover_.end())
-    return AGAIN;
-  body_.insert(body_.end(), leftover_.begin(), crlf_pos);
-  size_t insertedData = crlf_pos - leftover_.begin();
-  leftover_.erase(leftover_.begin(), crlf_pos + kCrlfLength);
-
-  // body 문법이 틀렸다면
-  if (insertedData != chunk_size_) {
-    response_status_code_ = 400;
-    return SUCCESS;
+  if (crlf_pos == leftover_.end()) {
+    return;
   }
+
+  size_t insertedData = crlf_pos - leftover_.begin();
+  if (insertedData != chunk_size_) {
+    parseComplete(400);
+    return;
+  }
+
+  body_.insert(body_.end(), leftover_.begin(), crlf_pos);
+  leftover_.erase(leftover_.begin(), crlf_pos + kCrlfLength);
   state_ = kChunkSize;
-  return AGAIN;
 }
 
-ReturnState RequestMessage::parseTrailerField() {
-  if (state_ != kTrailerField) {
-    return AGAIN;
-  }
+void RequestMessage::parseTrailerField() {
   vector_iterator line_pos;
   while (true) {
     line_pos = std::search(leftover_.begin(), leftover_.end(), kCrlf, kCrlf + kCrlfLength);
     if (line_pos == leftover_.end()) {
-      return AGAIN;
+      return;
     }
 
     std::string field_line(leftover_.begin(), line_pos);
     leftover_.erase(leftover_.begin(), line_pos + kCrlfLength);
     if (field_line.empty()) {
-      break;
+      parseComplete(200);
+      return;
     }
-    size_t colon_pos = field_line.find(':');
-    if (colon_pos != std::string::npos) {
-      std::string field_name(field_line.substr(0, colon_pos));
-      if (field_name.find(' ') != std::string::npos) {
-        response_status_code_ = 400;
-        state_ = kParseDone;
-        return SUCCESS;
-      }
-      std::for_each(field_name.begin(), field_name.end(), toLower);
-      std::string field_value(field_line.begin() + colon_pos + 1, field_line.end());
-      trim(field_value);
-      headers_[field_name] = field_value;
-    }
+    parseField(field_line);
   }
   // Todo: Remove "chunked" from Transer-Encoding;
-  state_ = kParseDone;
-  return SUCCESS;
 }
 
 const std::string &RequestMessage::getMethod(void) const {

--- a/src/RequestMessage.cpp
+++ b/src/RequestMessage.cpp
@@ -187,8 +187,7 @@ void RequestMessage::checkBodyType() {
   if (content_length != headers_.end()) {
     content_length_ = std::strtol(content_length->second.c_str(), NULL, 10);
     state_ = kContentLength;
-  }
-  if (chunked != headers_.end()) {
+  } else {
     content_length_ = 0;
     state_ = kChunkSize;
   }

--- a/src/RequestMessage.cpp
+++ b/src/RequestMessage.cpp
@@ -283,9 +283,7 @@ void RequestMessage::removeChunkedInHeader() {
   size_t pos = value.find("chunked");
   value.erase(pos, 7);
 
-  std::stringstream ss;
-  ss << content_length_;
-  headers_["content-length"] = ss.str();
+  headers_["content-length"] = numberToString(content_length_);
 }
 
 const std::string &RequestMessage::getMethod(void) const {

--- a/src/RequestMessage.cpp
+++ b/src/RequestMessage.cpp
@@ -270,12 +270,19 @@ void RequestMessage::parseTrailerField() {
     std::string field_line(leftover_.begin(), line_pos);
     leftover_.erase(leftover_.begin(), line_pos + kCrlfLength);
     if (field_line.empty()) {
+      removeChunkedInHeader();
       parseComplete(200);
       return;
     }
     parseField(field_line);
   }
-  // Todo: Remove "chunked" from Transer-Encoding;
+}
+
+void RequestMessage::removeChunkedInHeader() {
+  map_iterator it = headers_.find("transfer-encoding");
+  std::string &value = it->second;
+  size_t pos = value.find("chunked");
+  value.erase(pos, 7);
 }
 
 const std::string &RequestMessage::getMethod(void) const {

--- a/src/RequestMessage.cpp
+++ b/src/RequestMessage.cpp
@@ -16,7 +16,7 @@ static void toLower(char &c) {
 }
 
 RequestMessage::RequestMessage(int &response_status_code_)
-    : response_status_code_(response_status_code_), state_(kMethod), content_length_(-1), chunk_size_(-1) {}
+    : response_status_code_(response_status_code_), state_(kMethod), content_length_(0), chunk_size_(0) {}
 
 void RequestMessage::appendLeftover(const char *buffer, size_t n) {
   for (size_t i = 0; i < n; ++i) {
@@ -239,6 +239,7 @@ void RequestMessage::parseChunkSize() {
     state_ = kTrailerField;
     return;
   }
+  content_length_ += chunk_size_;
   state_ = kChunkData;
 }
 
@@ -283,6 +284,10 @@ void RequestMessage::removeChunkedInHeader() {
   std::string &value = it->second;
   size_t pos = value.find("chunked");
   value.erase(pos, 7);
+
+  std::stringstream ss;
+  ss << content_length_;
+  headers_["content-length"] = ss.str();
 }
 
 const std::string &RequestMessage::getMethod(void) const {

--- a/src/RequestMessage.cpp
+++ b/src/RequestMessage.cpp
@@ -105,9 +105,8 @@ void RequestMessage::parseProtocol() {
 
   protocol_.insert(protocol_.begin(), leftover_.begin(), crlf_pos);
   leftover_.erase(leftover_.begin(), crlf_pos + kCrlfLength);
-  std::for_each(protocol_.begin(), protocol_.end(), toLower);
 
-  if (protocol_ != "http/1.1") {
+  if (protocol_ != "HTTP/1.1") {
     parseComplete(400);
     return;
   }

--- a/src/RequestMessage.hpp
+++ b/src/RequestMessage.hpp
@@ -5,7 +5,7 @@
 
 #include <map>
 #include <string>
-#include <vector>
+#include <deque>
 
 #include "src/utils.hpp"
 
@@ -56,7 +56,7 @@ class RequestMessage {
   ParseState state_;
   ssize_t written_;
 
-  std::vector<char> leftover_;
+  std::deque<char> leftover_;
   ssize_t content_length_;
   ssize_t chunk_size_;
 

--- a/src/RequestMessage.hpp
+++ b/src/RequestMessage.hpp
@@ -30,7 +30,9 @@ class RequestMessage {
     kSkipCrlf,
     kHeaderLine,
     kContentLength,
-    kChunked,
+    kChunkSize,
+    kChunkData,
+    kTrailerField,
     kParseDone
   };
 
@@ -42,14 +44,17 @@ class RequestMessage {
   ReturnState parseHeaderLine();
   ReturnState checkBodyType();
   ReturnState parseContentLengthBody();
-  ReturnState parseChunkedBody();
+  ReturnState parseChunkBody();
+  ReturnState parseChunkSize();
+  ReturnState parseChunkData();
+  ReturnState parseTrailerField();
 
   ParseState state_;
   ssize_t written_;
 
   std::vector<char> leftover_;
   ssize_t content_length_;
-  ssize_t chunked_length_;
+  ssize_t chunk_size_;
 
   std::string method_;
   std::string uri_;

--- a/src/RequestMessage.hpp
+++ b/src/RequestMessage.hpp
@@ -36,21 +36,22 @@ class RequestMessage {
     kParseComplete
   };
 
-  void parseComplete(int response_status_code);
-
   void parseStartLine();
   void parseMethod();
   void parseUri();
   void parseProtocol();
   void skipCrlf();
   void parseHeaderLine();
-  void parseField(std::string &field);
-  void checkBodyType();
   void parseContentLengthBody();
   void parseChunkBody();
   void parseChunkSize();
   void parseChunkData();
   void parseTrailerField();
+
+  void parseComplete(int response_status_code);
+  void checkBodyType();
+  void parseField(std::string &field);
+  void removeChunkedInHeader();
 
   ParseState state_;
   ssize_t written_;

--- a/src/RequestMessage.hpp
+++ b/src/RequestMessage.hpp
@@ -33,21 +33,24 @@ class RequestMessage {
     kChunkSize,
     kChunkData,
     kTrailerField,
-    kParseDone
+    kParseComplete
   };
 
-  ReturnState parseStartLine();
-  ReturnState parseMethod();
-  ReturnState parseUri();
-  ReturnState parseProtocol();
-  ReturnState skipCrlf();
-  ReturnState parseHeaderLine();
-  ReturnState checkBodyType();
-  ReturnState parseContentLengthBody();
-  ReturnState parseChunkBody();
-  ReturnState parseChunkSize();
-  ReturnState parseChunkData();
-  ReturnState parseTrailerField();
+  void parseComplete(int response_status_code);
+
+  void parseStartLine();
+  void parseMethod();
+  void parseUri();
+  void parseProtocol();
+  void skipCrlf();
+  void parseHeaderLine();
+  void parseField(std::string &field);
+  void checkBodyType();
+  void parseContentLengthBody();
+  void parseChunkBody();
+  void parseChunkSize();
+  void parseChunkData();
+  void parseTrailerField();
 
   ParseState state_;
   ssize_t written_;

--- a/src/utils.hpp
+++ b/src/utils.hpp
@@ -3,6 +3,7 @@
 #ifndef SRC_UTILS_HPP_
 #define SRC_UTILS_HPP_
 
+#include <sstream>
 #include <string>
 #include <vector>
 
@@ -16,6 +17,13 @@ enum ReturnState {
 std::vector<std::string> split(std::string input, std::string delimiter);
 std::string skipCharset(std::string input, std::string charset);
 void trim(std::string& str);
+
+template <typename T>
+std::string numberToString(T number) {
+  std::stringstream ss;
+  ss << number;
+  return ss.str();
+}
 
 
 #endif //SRC_UTILS_HPP_

--- a/test/RequestParsingTest.cpp
+++ b/test/RequestParsingTest.cpp
@@ -11,11 +11,13 @@ int main() {
   int fd = open("test", O_RDONLY);
   if (fd <= 0)
     return 0;
-  char buf[1];
+  char buf[8000];
 
+  int a = 0;
   while (1) {
+    a++;
     int rd = read(fd, buf, sizeof(buf));
-    request_message.parse(buf, rd);
+    auto ret =  request_message.parse(buf, rd);
     std::cout << "METHOD : " << request_message.getMethod() << '\n';
     std::cout << "URI : " << request_message.getUri() << '\n';
     std::cout << "PROTOCOl : " << request_message.getAProtocol() << '\n';
@@ -29,8 +31,7 @@ int main() {
       std::cout << i;
     }
     std::cout << '\n';
-    if (rd == 0)
+    if (ret == SUCCESS)
       break ;
   }
-
 }


### PR DESCRIPTION
- [x] #22 

[Chunk base body 파싱 로직]
1. 헤더라인 파싱 완료 후 Chunk base body인지 확인하고, 맞다면 상태를 kChunkSize로 갱신한다.
2. kChunkSize라면 parseChunkSize메서드를 호출하여 본문이 얼마나 입력되는지 확인한다. 
만약 16진수가 아닌 문자가 온다면 에러로 간주하고 파싱을 종료한다. 
0 이상의 값이 왔으면 chunk_size_ 변수에 값을 담고  kChunkData 상태로 갱신한다. content_length_ 변수에 chunk_size_를 더한다.
0(본문 종료)값이 왔으면 상태를 kTrailerField로 갱신한다.
3. kChunkData 상태라면 leftover_를 확인하고 CRLF가 있다면 CRLF 이전까지 본문을 body_ 변수에 담는다.
만약 담은 값이 chunk_size보다 작다면 에러로 간주하고 파싱을 종료한다.
4. kChunkTrailer 상태라면 field line을 파싱한다. 
CRLF만 오면 파싱 종료로 판단하여 Transfer-Encoding 헤더에 chunked 값을 지우고, Content-length 헤더에 chunk_size_ 값을 추가한다.

[리팩터링]
기존에는 파싱 관련 메서드들의 반환값 AGAIN SUCCESS 값을 확인하여 파싱이 완료되었는지 판단했는데, kParseComplete 상태를 추가하여 kParseComplete 상태면 parse 메서드가 SUCCESS를 반환하도록 변경했습니다.
기존에는 메서드 내부에서 state_ 값을 확인하였는데, 메서드 호출 전 if문으로 state_ 값을 확인하도록 로직을 변경했습니다.

[확인해봐야 할 부분]
다른 웹서버 프로그램에서는 trailer field를 받을 때 공백 문자만 들어온 경우를 에러로 처리하는지

반성할 점
리팩터링이랑 기능 구현 두 부분을 나눠서 작업하고 따로 PR 올릴걸 그랬습니다
다음부터는 조심하겠습니다 ㅜ