### PR TITLE
22 implement request message parsing

### DIFF
--- a/src/RequestMessage.cpp
+++ b/src/RequestMessage.cpp
@@ -29,6 +29,8 @@ bool RequestMessage::writeDone() {
 void RequestMessage::clear() {
   state_ = kMethod;
   written_ = 0;
+  content_length_ = 0;
+  chunk_size_ = 0;
   method_.clear();
   uri_.clear();
   protocol_.clear();

--- a/src/RequestMessage.cpp
+++ b/src/RequestMessage.cpp
@@ -185,9 +185,10 @@ void RequestMessage::checkBodyType() {
   if (content_length != headers_.end()) {
     content_length_ = std::strtol(content_length->second.c_str(), NULL, 10);
     state_ = kContentLength;
-  } else {
-    content_length_ = 0;
+  } else if (chunked != headers_.end()){
     state_ = kChunkSize;
+  } else {
+    state_ = kParseComplete;
   }
 }
 

--- a/src/RequestMessage.cpp
+++ b/src/RequestMessage.cpp
@@ -2,10 +2,6 @@
 
 #include "src/RequestMessage.hpp"
 
-#include <sstream>
-
-#include "src/utils.hpp"
-
 typedef std::deque<char>::iterator deque_iterator;
 typedef std::map<std::string, std::string>::iterator map_iterator;
 

--- a/src/RequestMessage.cpp
+++ b/src/RequestMessage.cpp
@@ -10,7 +10,7 @@ static void toLower(char &c) {
 }
 
 RequestMessage::RequestMessage(int &response_status_code_)
-    : state_(kMethod), content_length_(0), chunk_size_(0), response_status_code_(response_status_code_){}
+    : state_(kMethod), content_length_(0), chunk_size_(0), response_status_code_(response_status_code_) {}
 
 void RequestMessage::appendLeftover(const char *buffer, size_t n) {
   for (size_t i = 0; i < n; ++i) {
@@ -24,6 +24,16 @@ bool RequestMessage::writeDone() {
     return true;
   }
   return false;
+}
+
+void RequestMessage::clear() {
+  state_ = kMethod;
+  written_ = 0;
+  method_.clear();
+  uri_.clear();
+  protocol_.clear();
+  headers_.clear();
+  body_.clear();
 }
 
 void RequestMessage::parseComplete(int response_status_code) {
@@ -181,7 +191,7 @@ void RequestMessage::checkBodyType() {
   if (content_length != headers_.end()) {
     content_length_ = std::strtol(content_length->second.c_str(), NULL, 10);
     state_ = kContentLength;
-  } else if (chunked != headers_.end()){
+  } else if (chunked != headers_.end()) {
     state_ = kChunkSize;
   } else {
     state_ = kParseComplete;

--- a/src/RequestMessage.hpp
+++ b/src/RequestMessage.hpp
@@ -15,6 +15,7 @@ class RequestMessage {
   void appendLeftover(const char *buffer, size_t n);
   ReturnState parse(const char *buffer, size_t read);
   bool writeDone();
+  void clear();
 
   const std::string &getMethod(void) const;
   const std::string &getUri() const;


### PR DESCRIPTION
- [ ] #22 
1. clear() 함수 구현
leftover_는 다음 request line이 buffer에 들어있을 가능성이 있어 clear하지 않았습니다.
2. 헤더 파싱이 종료됐고 본문이 없는 경우 상태가 파싱 완료 상태로 가지 않는 버그 해결
3. 필요없는 헤더 정리