### PR TITLE
63 errors

### DIFF
--- a/docs/conf/static.conf
+++ b/docs/conf/static.conf
@@ -4,7 +4,7 @@ cgi_version CGI/1.1
 status_path docs/conf/status_message.txt
 mime_path docs/conf/mime.txt
 cgi_path docs/cgi/cgi
-timeout 60
+timeout 10
 
 server {
   default_error_page_200 docs/html/200.html
@@ -13,7 +13,7 @@ server {
   default_error_page_500 docs/html/500.html
   client_body_size 1000000
   listen 0.0.0.0
-  port 8080
+  port 4242
   server_name localhost
   location / {
     root_dir docs/html

--- a/src/Connection.cpp
+++ b/src/Connection.cpp
@@ -159,8 +159,7 @@ void Connection::writingToSocket() {
   if (response_headers.at("Connection") == "close") {
     is_connection_close_ = true;
   }
-  request_message_.clear();
-  //TODO: clear connection
+  clear();
   state_ = kReadingFromSocket;
   kqueue_.setEvent(connection_socket_, EVFILT_READ, EV_ENABLE, 0, 0, this);
 }

--- a/src/Connection.cpp
+++ b/src/Connection.cpp
@@ -152,7 +152,9 @@ void Connection::writingToSocket() {
     is_connection_close_ = true;
   }
   request_message_.clear();
+  //TODO: clear connection
   state_ = kReadingFromSocket;
+  kqueue_.setEvent(connection_socket_, EVFILT_READ, EV_ENABLE, 0, 0, this);
 }
 
 void Connection::setConfigInfo() {

--- a/src/Connection.cpp
+++ b/src/Connection.cpp
@@ -22,10 +22,9 @@ int Connection::getConnectionSocket() const {
   return connection_socket_;
 }
 
-void Connection::parsingRequestMessage() {
-  ReturnState ret = request_message_.parse(read_buffer_, read_);
-  if (ret == AGAIN) {
-    return;
+ReturnState Connection::parsingRequestMessage() {
+  if (request_message_.parse(read_buffer_, read_) == AGAIN) {
+    return AGAIN;
   }
   // TODO: 파싱유효성 검사
   setConfigInfo();
@@ -67,14 +66,16 @@ void Connection::writingToPipe() {
   }
 }
 
-ReturnState Connection::work(void) {
+ReturnState Connection::work() {
   //   if (checkTimeOut()){
   //     // connectionClose();
   //     return CONNECTION_CLOSE;
   //   }
   switch (state_) {
-    case PARSING_REQUEST_MESSAGE:parsingRequestMessage();
-      break;
+    case PARSING_REQUEST_MESSAGE:
+      if (parsingRequestMessage() == AGAIN) {
+        break;
+      }
     case HANDLING_STATIC_PAGE:handlingStaticPage();
       break;
     case HANDLING_DYNAMIC_PAGE_HEADER:break;

--- a/src/Connection.hpp
+++ b/src/Connection.hpp
@@ -29,9 +29,9 @@ class Connection {
   bool checkReadSuccess();
   bool checkTimeOut();
   void setConfigInfo();
-  ReturnState parsingRequestMessage();
-  ReturnState handlingStaticPage();
-  ReturnState writingStaticPage();
+  void parsingRequestMessage();
+  void handlingStaticPage();
+  void writingToSocket();
   ReturnState executeCgiProcess();
   void openStaticPage();
   void writingToPipe();
@@ -76,6 +76,7 @@ class Connection {
 
   struct sockaddr_in client_addr_;
   time_t time_;
+  bool is_connection_close_;
   State state_;
 };
 

--- a/src/Connection.hpp
+++ b/src/Connection.hpp
@@ -29,7 +29,7 @@ class Connection {
   bool checkReadSuccess();
   bool checkTimeOut();
   void setConfigInfo();
-  void parsingRequestMessage();
+  ReturnState parsingRequestMessage();
   ReturnState handlingStaticPage();
   ReturnState writingStaticPage();
   ReturnState executeCgiProcess();

--- a/src/Connection.hpp
+++ b/src/Connection.hpp
@@ -27,7 +27,7 @@ class Connection {
   char *getReadBuffer();
   ReturnState work();
   bool checkReadSuccess();
-  bool checkTimeOut();
+  bool isTimeOut();
   void setConfigInfo();
   void parsingRequestMessage();
   void handlingStaticPage();
@@ -38,6 +38,7 @@ class Connection {
   ReturnState writeHandler(const struct kevent &event);
   ReturnState readHandler(const struct kevent &event);
   void closeConnection();
+  void clear();
 
  private:
   enum State {
@@ -51,7 +52,6 @@ class Connection {
   char **setMetaVariables(std::map<std::string, std::string> &env);
 
   int connection_socket_;
-  int file_fd_;
   int pipe_read_fd_;
   int pipe_write_fd_;
   int response_status_code_;

--- a/src/Connection.hpp
+++ b/src/Connection.hpp
@@ -41,14 +41,10 @@ class Connection {
 
  private:
   enum State {
-    PARSING_REQUEST_MESSAGE,
-    HANDLING_STATIC_PAGE,
-    HANDLING_DYNAMIC_PAGE_HEADER,
-    HANDLING_DYNAMIC_PAGE_BODY,
-    WRITING_TO_PIPE,
-    WRITING_STATIC_PAGE,
-    WRITING_DYNAMIC_PAGE_HEADER,
-    WRITING_DYNAMIC_PAGE_BODY
+    kReadingFromSocket,
+    kWritingToPipe,
+    kReadingFromPipe,
+    kWritingToSocket
   };
 
   ReturnState checkFileReadDone();

--- a/src/RequestMessage.cpp
+++ b/src/RequestMessage.cpp
@@ -36,7 +36,6 @@ void RequestMessage::clear() {
   protocol_.clear();
   headers_.clear();
   body_.clear();
-  response_status_code_ = 200;
 }
 
 void RequestMessage::parseComplete(int response_status_code) {

--- a/src/ResponseMessage.cpp
+++ b/src/ResponseMessage.cpp
@@ -118,6 +118,14 @@ void ResponseMessage::createResponseMessage(const RequestMessage& request_messag
   response_message_.insert(response_message_.end(), body_.begin(), body_.end());
 }
 
+void ResponseMessage::clear() {
+  headers_.clear();
+  status_line_.clear();
+  header_line_.clear();
+  body_.clear();
+  response_message_.clear();
+}
+
 const std::vector<char> &ResponseMessage::getStatusLine() const {
   return status_line_;
 }

--- a/src/ResponseMessage.hpp
+++ b/src/ResponseMessage.hpp
@@ -22,6 +22,7 @@ class ResponseMessage {
   const std::map<std::string, std::string> &getHeaders() const;
   const std::vector<char> &getResponseMessage() const;
   void createBody(const std::string &path);
+  void clear();
 
  private:
   void createStatusLine();

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -47,7 +47,7 @@ static void eraseConnection(Connection *ptr, std::set<Connection*> &connections,
   ptr->closeConnection();
   delete ptr;
   connections.erase(ptr);
-  for (std::deque<Connection*>::iterator it; it != work_queue.end(); ++it) {
+  for (std::deque<Connection*>::iterator it = work_queue.begin(); it != work_queue.end(); ++it) {
     if (*it == ptr) {
       work_queue.erase(it);
       break;

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -56,11 +56,14 @@ static void eraseConnection(Connection *ptr, std::set<Connection*> &connections,
 }
 
 void Server::run() {
+  struct timespec timeout;
+  timeout.tv_sec = 1;
+  timeout.tv_nsec = 0;
   std::set<Connection*> connections;
   std::deque<Connection*> work_queue;
   struct kevent event_list[10];
   while (1) {
-    int detected_cnt = kevent(kqueue_.fd_, NULL, 0, event_list, 10, NULL);
+    int detected_cnt = kevent(kqueue_.fd_, NULL, 0, event_list, 10, &timeout);
     for (int i = 0; i < detected_cnt; ++i) {
       int id = event_list[i].ident;
       int filter = event_list[i].filter;

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -56,9 +56,7 @@ static void eraseConnection(Connection *ptr, std::set<Connection*> &connections,
 }
 
 void Server::run() {
-  struct timespec timeout;
-  timeout.tv_sec = 1;
-  timeout.tv_nsec = 0;
+  struct timespec timeout = {0, 0};
   std::set<Connection*> connections;
   std::deque<Connection*> work_queue;
   struct kevent event_list[10];


### PR DESCRIPTION
주요 변경사항
- #63 
- 동일 클라이언트가 새로고침으로 연결 시도 했을 때 segfault
    - chrome은 새로고침을 하면 새로운 connection 연결을 시도한다(기존 연결에 다시 요청을 보내는 것이 아님)
    - 하나의 커넥션에서 응답 메세지를 모두 보냈다면 kReadingFromSocket 상태로 변경하고 read event를 enable 하는 것으로 해결
- I/O 작업이 필요 없는데 work() 함수에서 나가는 문제
    - I/O 작업이 필요할 때를 기준으로 connection의 상태를 다시 refactoring하여 해결
- timeout 체크 로직 구현
    - isTimeOut 함수 구현 
    - kevent 함수에 default timeout값을 1초로 지정함으로서 event가 없을 때 timeout 체크를 못하는 상황을 해결함
- connection clear() 함수 구현
    - 응답메세지를 보내고 나서 지속커넥션으로 해당 커넥션 객체를 재활용하기 위해 멤버 변수들을 초기화 하는 함수를 구현  